### PR TITLE
Support Vagrant 1.1 at least for 'vagrant status'

### DIFF
--- a/vagrant.py
+++ b/vagrant.py
@@ -29,6 +29,7 @@ Dependencies:
 '''
 
 import os
+import re
 import subprocess
 import sys
 
@@ -172,12 +173,15 @@ class Vagrant(object):
         output = self._run_vagrant_command('status', vm_name)
         # sys.stderr.write('status {}: {}\n'.format(vm_name, output))
         statuses = {}
-        state = 1 # parsing state variable.
-        # The format of output is expected to be a "Current VM states:" line
+        # The format of output is expected to be a 
+        #   - "Current VM states:" line (vagrant 1)
+        #   - "Current machine states" line (vagrant 1.1)
         # followed by a blank line, followed by one or more status lines,
         # followed by a blank line.
+        state = 1
         for line in output.splitlines():
-            if state == 1 and line.strip().startswith('Current VM states:'):
+
+            if state == 1 and re.search('^Current (VM|machine) states:', line.strip()):
                 state = 2
             elif state == 2 and not line.strip():
                 state = 3


### PR DESCRIPTION
Now allows the following output for vagrant status:

```
Current machine states:   # Vagrant 1.1
Current VM states:        # Vagrant .. 0.X + 1 ?
```

Thanks for the other parts of the module ! Will commit more if I find other stuff (just started digging...)
