### PR TITLE
Update config parser to allow warning from vagrant ssh-config

### DIFF
--- a/vagrant.py
+++ b/vagrant.py
@@ -382,11 +382,9 @@ class Vagrant(object):
                 started_parsing = True
             if not started_parsing or not line.strip() or line.strip().startswith('#'):
                 continue
-            keyval = line.strip().split(None, 1)
-            conf[keyval[0]] = keyval[1]
-        # Cleanup double quotes for IdentityFile
-        if conf['IdentityFile']:
-            conf['IdentityFile'] = conf['IdentityFile'].strip('"')
+            key, value = line.strip().split(None, 1)
+            # Remove leading and trailing " from the values
+            conf[key] = value.strip('"')
         return conf
 
     def _run_vagrant_command(self, *args):


### PR DESCRIPTION
Vagrant may spit warning messages in the following format just before the config:

```
There were warnings and/or errors while loading your Vagrantfile.
Your Vagrantfile was written for an earlier version of Vagrant,
and while Vagrant does the best it can to remain backwards
compatible, there are some cases where things have changed
significantly enough to warrant a message. These messages are
shown below.

Warnings:
* `config.vm.customize` calls are VirtualBox-specific. If you're
using any other provider, you'll have to find provider-specific configuration
to translate to manually in your Vagrantfile.
```

I moved forward on a regex matching approach of the message to capture each of the component of the ssh-config. 

Another approach would be the same as what you had for the parsing of the vagrant status, with a status variable and simply cut away the lines before matching a `Host xyz`
