### PR TITLE
Remove provider from status (Vagrant 1.1)

### DIFF
--- a/vagrant.py
+++ b/vagrant.py
@@ -188,7 +188,7 @@ class Vagrant(object):
                 state = 3
             elif state == 3 and line.strip():
                 this_vm_name, status = line.strip().split(None, 1)
-                statuses[this_vm_name] = status
+                statuses[this_vm_name] = status.split('(')[0].strip()
             elif state == 3 and not line.strip():
                 break
 


### PR DESCRIPTION
Current status includes the provider in the following format: 

```
Current machine states:

testbox10                running (virtualbox)
testbox20                not created (virtualbox)
```

This PR strip the provider name out of the status and would return the following: 

```
>>> import vagrant ; v = vagrant.Vagrant() ; v.status()
{'testbox20': 'not created', 'testbox10': 'running'}
```
