### PR TITLE
Add ability for up to take a provider option

### DIFF
--- a/vagrant.py
+++ b/vagrant.py
@@ -158,7 +158,7 @@ class Vagrant(object):
         Launch the Vagrant box.
         '''
         no_provision_arg = '--no-provision' if no_provision else None
-        provider_arg = '--provider %s' % provider if provider else None
+        provider_arg = '--provider=%s' % provider if provider else None
         self._run_vagrant_command('up', vm_name, no_provision_arg, provider_arg)
         try:
             self.conf(vm_name=vm_name)  # cache configuration


### PR DESCRIPTION
When trying to launch a vagrant instance using a provider other than virtualbox, up will fail as of vagrant 1.2.4. This allows for that flag to be specified and passed on to vagrant.
