### PR TITLE
Return a dictionary from status() in all cases

### DIFF
--- a/vagrant.py
+++ b/vagrant.py
@@ -192,10 +192,10 @@ class Vagrant(object):
 
     def status(self, vm_name=None):
         '''
-        Returns the status of a Vagrant box or a dictionary mapping vm names
-        to statuses.  Statuses are RUNNING, POWEROFF, SAVED and NOT_CREATED,
-        corresponding to vagrant up, halt, suspend, and destroy, respectively.
-        
+        Returns a dictionary mapping Vagrant box names to statuses.  Statuses
+        are RUNNING, POWEROFF, SAVED and NOT_CREATED, corresponding to vagrant
+        up, halt, suspend, and destroy, respectively.
+
         In a single-VM environment or when the vm_name parameter is used in
         a multi-VM environment, a status string is returned:
 
@@ -265,15 +265,7 @@ class Vagrant(object):
             elif state == 3 and not line.strip():
                 break
 
-        if len(statuses) == 0:
-            # no status found
-            return None
-        elif len(statuses) == 1:
-            # single-VM environment or multi-VM env and vm_name arg given.
-            return statuses.values()[0]
-        else:
-            # multi-VM environment
-            return statuses
+        return statuses
 
     def conf(self, ssh_config=None, vm_name=None):
         '''


### PR DESCRIPTION
I find consistent APIs much easier to use. For example, when all I want to do is iterate over the statuses of all the VMs, this patch lets me handle only one case, rather than three.
