### PR TITLE
Fixed setup parameters to fit package structure

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,6 @@ setup(
                    'Programming Language :: Python :: 2',
                    'Programming Language :: Python :: 2.7',
                   ],
-    py_modules = ['vagrant'],
+    packages = ['vagrant'],
 )
 


### PR DESCRIPTION
setup.py setup call failed when running `pip install python-vagrant`. 
