### PR TITLE
Add support LXC statuses 'frozen' and 'stopped'

### DIFF
--- a/vagrant/__init__.py
+++ b/vagrant/__init__.py
@@ -118,7 +118,12 @@ class Vagrant(object):
     POWEROFF = 'poweroff'  # vagrant halt
     ABORTED = 'aborted'  # The VM is in an aborted state
     SAVED = 'saved' # vagrant suspend
-    STATUSES = (RUNNING, NOT_CREATED, POWEROFF, ABORTED, SAVED)
+
+    # LXC statuses
+    STOPPED = 'stopped'
+    FROZEN = 'frozen'
+
+    STATUSES = (RUNNING, NOT_CREATED, POWEROFF, ABORTED, SAVED, STOPPED, FROZEN)
 
     BASE_BOXES = {
         'ubuntu-Lucid32': 'http://files.vagrantup.com/lucid32.box',


### PR DESCRIPTION
LXC has the statuses 'frozen' and 'stopped'. These are currently not supported in python-vagrant.
