### PR TITLE
Do not throw exception if return-code is != 0

### DIFF
--- a/vagrant/__init__.py
+++ b/vagrant/__init__.py
@@ -532,7 +532,10 @@ class Vagrant(object):
         if not kwargs.get('capture_output', True):
             subprocess.call(command, cwd=self.root)
         else:
-            return subprocess.check_output(command, cwd=self.root)
+            try:
+                return subprocess.check_output(command, cwd=self.root)
+            except subprocess.CalledProcessError as e:
+                return e.output
 
     def _confirm(self, prompt=None, resp=False):
         '''


### PR DESCRIPTION
With vagrant 1.5, calling vagrant sandbox status without the sahara pluging installed will return with an exit code1 and subprocess.call raise an Exception if return code != 0.

So I catch the exception and return the output anyway.
