### PR TITLE
don't die if vagrant-exe is missing until it is used

### DIFF
--- a/tests/test_vagrant.py
+++ b/tests/test_vagrant.py
@@ -471,8 +471,13 @@ def _execute_command_in_vm(v, command):
     Run command via ssh on the test vagrant box.  Returns a tuple of the
     return code and output of the command.
     '''
+    vagrant_exe = vagrant.get_vagrant_executable()
+
+    if not vagrant_exe:
+        raise RuntimeError(vagrant.VAGRANT_NOT_FOUND_WARNING)
+
     # ignore the fact that this host is not in our known hosts
-    ssh_command = [vagrant.VAGRANT_EXE, 'ssh', '-c', command]
+    ssh_command = [vagrant_exe, 'ssh', '-c', command]
     return subprocess.check_output(ssh_command, cwd=v.root)
 
 


### PR DESCRIPTION
We've written a simple vagrant driver for libcloud. This driver uses python-vagrant for all the actual vagrant stuff. The unittests for our driver and the surrounding libraries do not require actually booting any instances.

However, our unittests will fail if vagrant is not installed, because `vagrant/__init__.py` dies on import if it can't find the vagrant binary. While I understand why you did this (why use this module if you don't have vagrant, right?) it makes it quite difficult to write a lean library that uses python-vagrant.

This PR replaces the assertion on import with a warning, and will trigger an exception at runtime.

Another approach might be to move the `which`-function to a separate utils-module. That would make it possible to patch `utils.which` to return True in our tests, before `vagrant` gets imported. I think removing the assertion from global namespace is a better solution though.
