### PR TITLE
Update __init__.py

### DIFF
--- a/vagrant/__init__.py
+++ b/vagrant/__init__.py
@@ -88,7 +88,13 @@ def which(program):
 
 # The full path to the vagrant executable, e.g. '/usr/bin/vagrant'
 def get_vagrant_executable():
-    return which('vagrant')
+    if (which('vagrant') is not None):
+        if (os.name == 'nt'):
+            return 'vagrant'
+        else:
+            return which('vagrant')
+    else:
+        return None
 
 
 if get_vagrant_executable() is None:


### PR DESCRIPTION
In my Windows distribution this does not work. I am using Cygwin and Cygwin does not recognize "C:\Pythonxx\Lib\site-packages\vagrant.EXE'. Cygwin just uses 'vagrant' instead. Please return just the keyword 'vagrant' instead of the full path at this line.
