### PR TITLE
Adding support for the resume command

### DIFF
--- a/vagrant/__init__.py
+++ b/vagrant/__init__.py
@@ -272,6 +272,13 @@ class Vagrant(object):
         self._call_vagrant_command(['suspend', vm_name])
         self._cached_conf[vm_name] = None  # remove cached configuration
 
+    def resume(self, vm_name=None):
+        '''
+        Resume suspended machine.
+        '''
+        self._call_vagrant_command(['resume', vm_name])
+        self._cached_conf[vm_name] = None  # remove cached configuration
+
     def halt(self, vm_name=None, force=False):
         '''
         Halt the Vagrant box.


### PR DESCRIPTION
The python-vagrant can suspend virtual machine. How about resume it?
https://docs.vagrantup.com/v2/cli/resume.html
