### PR TITLE
Python3 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ and make sure any existing tests still work.  One can test with:
 - Vagrant 1.1 or greater (urrently tested with 1.5).  Using the latest version
   of Vagrant is strongly recommended.
 - Vagrant requires VirtualBox (e.g. VirtualBox 4.2.10) or another provider.
-- Python 2.7 (the only version this package has been tested with.)
+- Python 2.7 or Python 3.3+. Python 3.4 and 2.7 are recommended.
 - The Sahara gem for Vagrant is optional.  It will allow you to use
   `SandboxVagrant`.
 

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,8 @@ setup(
                    'Development Status :: 4 - Beta',
                    'Programming Language :: Python :: 2',
                    'Programming Language :: Python :: 2.7',
+                   'Programming Language :: Python :: 3.3',
+                   'Programming Language :: Python :: 3.4',
                   ],
-    packages = ['vagrant'],
+    packages = ['vagrant', 'future'],
 )

--- a/setup.py
+++ b/setup.py
@@ -28,5 +28,8 @@ setup(
                    'Programming Language :: Python :: 3.3',
                    'Programming Language :: Python :: 3.4',
                   ],
-    packages = ['vagrant', 'future'],
+    install_requires = [
+        'future>=0.14.3',
+    ],
+    packages = ['vagrant'],
 )

--- a/tests/test_vagrant.py
+++ b/tests/test_vagrant.py
@@ -66,12 +66,19 @@ def list_boxes():
     # precise64                (virtualbox)
     # python-vagrant-base      (virtualbox)
     # python-vagrant-dummy-box (virtualbox)
+    #
     # Example `box list` output with no boxes (vagrant 1.2.7):
     # There are no installed boxes! Use `vagrant box add` to add some.
+    #
+    # With multiple providers 'box list' output (vagrant 1.6):
+    # precise64                (virtualbox, 0)
+    # python-vagrant-base      (virtualbox, 0)
+    # ubuntu1204-large         (openstack, 0)
+    # ubuntu1204-medium        (openstack, 0)
     listing = subprocess.check_output('vagrant box list', shell=True)
     boxes = []
     for line in listing.splitlines():
-        m = re.search(r'^\s*(?P<name>.+?)\s+\((?P<provider>[^)]+)\)\s*$', line)
+        m = re.search(r'^\s*(?P<name>.+?)\s+\((?P<provider>[\w]+)[^)]*\)\s*$', line)
         if m:
             print m.groups()
             boxes.append((m.group('name'), m.group('provider')))

--- a/tests/test_vagrant.py
+++ b/tests/test_vagrant.py
@@ -20,8 +20,10 @@ TEST_BOX_NAME. This box is not deleted after the test suite runs in order
 to avoid downloading of the box file on every run.
 '''
 
+from __future__ import print_function
 
 import os
+import locale
 import re
 import unittest
 import shutil
@@ -77,10 +79,11 @@ def list_boxes():
     # ubuntu1204-medium        (openstack, 0)
     listing = subprocess.check_output('vagrant box list', shell=True)
     boxes = []
+    encoding = locale.getpreferredencoding()
     for line in listing.splitlines():
-        m = re.search(r'^\s*(?P<name>.+?)\s+\((?P<provider>[\w]+)[^)]*\)\s*$', line)
+        m = re.search('^\s*(?P<name>.+?)\s+\((?P<provider>[\w]+)[^)]*\)\s*$', line.decode(encoding))
         if m:
-            print m.groups()
+            print(m.groups())
             boxes.append((m.group('name'), m.group('provider')))
     return boxes
 
@@ -158,6 +161,20 @@ def teardown_vm():
         os.unlink(os.path.join(TD, "Vagrantfile"))
 
 
+def parse_ssh_config(cwd, vm_name=''):
+    '''
+    Calls vagrant ssh-config and returns dictionnary of the values.
+    '''
+    command = "vagrant ssh-config " + vm_name
+    ssh_config = subprocess.check_output(command, cwd=cwd, shell=True)
+    parsed_config = dict()
+    encoding = locale.getpreferredencoding()
+    for line in ssh_config.splitlines():
+        if line.strip() and not line.strip().startswith(b'#'):
+            decoded = line.decode(encoding).strip().split(None, 1)
+            parsed_config[decoded[0]] = decoded[1]
+    return parsed_config
+
 
 @with_setup(make_setup_vm(), teardown_vm)
 def test_plugin_list_parsing():
@@ -229,11 +246,8 @@ def test_vm_config():
     '''
     v = vagrant.Vagrant(TD)
     v.up()
-    command = "vagrant ssh-config"
-    ssh_config = subprocess.check_output(command, cwd=TD, shell=True)
-    parsed_config = dict(line.strip().split(None, 1) for line in
-                            ssh_config.splitlines() if line.strip() and not
-                            line.strip().startswith('#'))
+
+    parsed_config = parse_ssh_config(cwd=TD)
 
     user = v.user()
     expected_user = parsed_config["User"]
@@ -299,36 +313,36 @@ def test_vm_sandbox_mode():
     assert sandbox_status == "on", "After bringing the VM up again the status should be 'on', " + "got:'{}'".format(sandbox_status)
 
     test_file_contents = _read_test_file(v)
-    print test_file_contents
+    print(test_file_contents)
     eq_(test_file_contents, None, "There should be no test file")
 
     _write_test_file(v, "foo")
     test_file_contents = _read_test_file(v)
-    print test_file_contents
+    print(test_file_contents)
     eq_(test_file_contents, "foo", "The test file should read 'foo'")
 
     v.sandbox_rollback()
     time.sleep(10)  # https://github.com/jedi4ever/sahara/issues/16
 
     test_file_contents = _read_test_file(v)
-    print test_file_contents
+    print(test_file_contents)
     eq_(test_file_contents, None, "There should be no test file")
 
     _write_test_file(v, "foo")
     test_file_contents = _read_test_file(v)
-    print test_file_contents
+    print(test_file_contents)
     eq_(test_file_contents, "foo", "The test file should read 'foo'")
     v.sandbox_commit()
     _write_test_file(v, "bar")
     test_file_contents = _read_test_file(v)
-    print test_file_contents
+    print(test_file_contents)
     eq_(test_file_contents, "bar", "The test file should read 'bar'")
 
     v.sandbox_rollback()
     time.sleep(10)  # https://github.com/jedi4ever/sahara/issues/16
 
     test_file_contents = _read_test_file(v)
-    print test_file_contents
+    print(test_file_contents)
     eq_(test_file_contents, "foo", "The test file should read 'foo'")
 
     sandbox_status = v._parse_vagrant_sandbox_status("Usage: ...")
@@ -394,8 +408,8 @@ def test_provisioning():
     eq_(test_file_contents, None, "There should be no test file after up()")
 
     v.provision()
-    test_file_contents = _read_test_file(v)
-    print "Contents: {}".format(test_file_contents)
+    test_file_contents = _read_test_file(v).decode(locale.getpreferredencoding())
+    print("Contents: {}".format(test_file_contents))
     eq_(test_file_contents, "foo", "The test file should contain 'foo'")
 
 
@@ -440,11 +454,8 @@ def test_multivm_config():
     '''
     v = vagrant.Vagrant(TD, quiet_stdout=False, quiet_stderr=False)
     v.up(vm_name=VM_1)
-    command = "vagrant ssh-config " + VM_1
-    ssh_config = subprocess.check_output(command, cwd=TD, shell=True)
-    parsed_config = dict(line.strip().split(None, 1) for line in
-                            ssh_config.splitlines() if line.strip() and not
-                            line.strip().startswith('#'))
+
+    parsed_config = parse_ssh_config(cwd=TD, vm_name=VM_1)
 
     user = v.user(vm_name=VM_1)
     expected_user = parsed_config["User"]

--- a/vagrant/__init__.py
+++ b/vagrant/__init__.py
@@ -603,9 +603,21 @@ class Vagrant(object):
             [Plugin(name='sahara', version='0.0.16', system=False),
              Plugin(name='vagrant-login', version='1.0.1', system=True),
              Plugin(name='vagrant-share', version='1.0.1', system=True)]
+             
+        Added condition is to ignore invalid lines insted of failing.
+        'vagrant-hostmanager (0.4.2.3)
+            - Version Constraint: 0.4.2.3'
+        is a possible and valid output
         '''
+        
         output = self._run_vagrant_command(['plugin', 'list'])
-        return [self._parse_plugin_list_line(l) for l in output.splitlines()]
+        plugins = []
+        for l in output.splitlines():
+            plugin = self._parse_plugin_list_line(l)
+            if plugin:
+                plugins.append(plugin)
+        return plugins
+
 
     def _parse_plugin_list_line(self, line):
         # As of Vagrant 1.5, the format of the `vagrant plugin list` command can
@@ -616,9 +628,7 @@ class Vagrant(object):
         # vagrant-login (1.0.1, system)
         regex = re.compile(r'^(?P<name>.+?)\s+\((?P<version>.+?)(?P<system>, system)?\)$')
         m = regex.search(line)
-        if m is None:
-            raise Exception('Error parsing plugin listing line.', line)
-        else:
+        if m is not None:
             return Plugin(m.group('name'), m.group('version'), bool(m.group('system')))
 
     def _parse_provider_line(self, line):

--- a/vagrant/__init__.py
+++ b/vagrant/__init__.py
@@ -643,8 +643,7 @@ class Vagrant(object):
             ('precise32', 'virtualbox')
             ('default                  not created', 'virtualbox')
         '''
-        m = re.search(r'^\s*(?P<value>.+?)\s+\((?P<provider>[^)]+)\)\s*$',
-                          line)
+        m = re.search(r'^\s*(?P<value>.+?)\s+\((?P<provider>[\w]+)[^)]*\)\s*$', line)
         if m:
             return m.group('value'), m.group('provider')
         else:

--- a/vagrant/__init__.py
+++ b/vagrant/__init__.py
@@ -21,7 +21,7 @@ import logging
 
 # python package version
 # should match r"^__version__ = '(?P<version>[^']+)'$" for setup.py
-__version__ = '0.5.2'
+__version__ = '0.5.4'
 
 
 log = logging.getLogger(__name__)

--- a/vagrant/__init__.py
+++ b/vagrant/__init__.py
@@ -10,6 +10,7 @@ Documentation of usage, testing, installation, etc., can be found at
 https://github.com/todddeluca/python-vagrant.
 '''
 
+import locale
 import collections
 import os
 import re
@@ -603,13 +604,13 @@ class Vagrant(object):
             [Plugin(name='sahara', version='0.0.16', system=False),
              Plugin(name='vagrant-login', version='1.0.1', system=True),
              Plugin(name='vagrant-share', version='1.0.1', system=True)]
-             
+
         Added condition is to ignore invalid lines insted of failing.
         'vagrant-hostmanager (0.4.2.3)
             - Version Constraint: 0.4.2.3'
         is a possible and valid output
         '''
-        
+
         output = self._run_vagrant_command(['plugin', 'list'])
         plugins = []
         for l in output.splitlines():
@@ -734,7 +735,8 @@ class Vagrant(object):
         '''
         # Make subprocess command
         command = self._make_vagrant_command(args)
-        return subprocess.check_output(command, cwd=self.root)
+        encoding = locale.getpreferredencoding()
+        return subprocess.check_output(command, cwd=self.root).decode(encoding)
 
 
 class SandboxVagrant(Vagrant):


### PR DESCRIPTION
First 3 commits were to adapt python-vagrant to work with multiple vagrant providers.

Changes for actual python 3 support (commit c021d79):
- Add print function for python 2.x with future.
- Convert byte strings from input to unicode string.