### PR TITLE
Make code base compatible with Python 3.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,8 @@ setup(
                    'Development Status :: 4 - Beta',
                    'Programming Language :: Python :: 2',
                    'Programming Language :: Python :: 2.7',
+                   'Programming Language :: Python :: 3.3',
+                   'Programming Language :: Python :: 3.4',
                   ],
     packages = ['vagrant'],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,18 @@
+[tox]
+envlist = py27, py34
+
+[testenv]
+deps = nose==1.3.7
+       # coloured output for nosetests
+       rednose==0.4.3
+
+commands = nosetests --immediate --stop -vv --rednose
+
+passenv =
+    # Pass HOME to the test environment as it is required by
+    # vagrant. Otherwise error happens due to missing HOME env variable.
+    HOME
+
+[testenv:dev]
+
+commands = {posargs}

--- a/vagrant/__init__.py
+++ b/vagrant/__init__.py
@@ -10,6 +10,7 @@ Documentation of usage, testing, installation, etc., can be found at
 https://github.com/todddeluca/python-vagrant.
 '''
 
+# std
 import collections
 import contextlib
 import itertools
@@ -18,6 +19,9 @@ import re
 import subprocess
 import sys
 import logging
+
+# local
+from . import compat
 
 
 # python package version
@@ -871,8 +875,8 @@ class Vagrant(object):
         # Make subprocess command
         command = self._make_vagrant_command(args)
         with self.err_cm() as err_fh:
-            return subprocess.check_output(command, cwd=self.root,
-                                           env=self.env, stderr=err_fh)
+            return compat.decode(subprocess.check_output(command, cwd=self.root,
+                                               env=self.env, stderr=err_fh))
 
 
 class SandboxVagrant(Vagrant):

--- a/vagrant/compat.py
+++ b/vagrant/compat.py
@@ -1,0 +1,24 @@
+"""
+vagrant.compat
+--------------
+
+Python 2/3 compatiblity module.
+"""
+
+# std
+import locale
+import sys
+
+
+PY2 = sys.version_info[0] == 2
+
+
+def decode(value):
+    """Decode binary data to text if needed (for Python 3).
+
+    Use with the functions that return in Python 2 value of `str` type and for Python 3 encoded bytes.
+
+    :param value: Encoded bytes for Python 3 and `str` for Python 2.
+    :return: Value as a text.
+    """
+    return value.decode(locale.getpreferredencoding()) if not PY2 else value

--- a/vagrant/test.py
+++ b/vagrant/test.py
@@ -3,7 +3,7 @@ A TestCase class, tying together the Vagrant class and removing some of the boil
 that leverage vagrant boxes.
 """
 from unittest import TestCase
-from vagrant import Vagrant
+from vagrant import Vagrant, stderr_cm
 
 __author__ = 'nick'
 
@@ -31,7 +31,7 @@ class VagrantTestCase(TestCase):
 
 	def __init__(self, *args, **kwargs):
 		"""Check that the vagrant_boxes attribute is not left empty, and is populated by all boxes if left blank"""
-		self.vagrant = Vagrant(self.vagrant_root)
+		self.vagrant = Vagrant(self.vagrant_root, err_cm=stderr_cm)
 		if not self.vagrant_boxes:
 			boxes = [s.name for s in self.vagrant.status()]
 			if len(boxes) == 1:


### PR DESCRIPTION
Problem
-------

Code base requires additional alignment to be compatible with Python 3.

Solution
--------

* `print` statement to function.
* `subprocess.check_output` in Python 3 returns result of type `bytes`,
expected `str`.

Testing
-------

Added `tox` configuration to run nose tests for both 2.7 and 3.4.

Run command:

    tox