### PR TITLE
Adds support for Vagrant 1.8

### DIFF
--- a/vagrant/__init__.py
+++ b/vagrant/__init__.py
@@ -804,6 +804,10 @@ class Vagrant(object):
         # type is the type of data, e.g. 'provider-name', 'box-version'
         # data is a (possibly comma separated) type-specific value, e.g. 'virtualbox', '0'
         parsed_lines = [line.split(',', 3) for line in output.splitlines() if line.strip()]
+        # vagrant 1.8 adds additional fields that aren't required,
+        # and will break parsing if included in the status lines.
+        # filter them out pending future implementation.
+        parsed_lines = list(filter(lambda x: x[2] != "metadata" and x[2] != "ui", parsed_lines))
         return parsed_lines
 
     def _parse_config(self, ssh_config):

--- a/vagrant/__init__.py
+++ b/vagrant/__init__.py
@@ -803,7 +803,7 @@ class Vagrant(object):
         # target is the VM name
         # type is the type of data, e.g. 'provider-name', 'box-version'
         # data is a (possibly comma separated) type-specific value, e.g. 'virtualbox', '0'
-        parsed_lines = [line.split(',', 3) for line in output.splitlines() if line.strip()]
+        parsed_lines = [line.split(',', 4) for line in output.splitlines() if line.strip()]
         # vagrant 1.8 adds additional fields that aren't required,
         # and will break parsing if included in the status lines.
         # filter them out pending future implementation.


### PR DESCRIPTION
See #45 for details on the breaking changes introduced in Vagrant 1.8. This PR accommodates for the changes by stripping out the incompatible lines returned by `--machine-readable`, namely the `metadata` and `ui` lines.

Updates the test suite to handle variance in the number of fields returned by `--machine-readable`, as well as private key paths bounded by double quotes (also a change introduced in 1.8).

All tests are passing under the following Vagrant versions:
* `1.7.2` (listed in the `README`)
* `1.7.4` (previous version)
* `1.8.0` (most recent version)

Resolves #45.